### PR TITLE
Docker Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ phlough will install composer dependencies, build assets, serve the project thro
 
 Optionally run `bin/console doctrine:fixtures:load` to import some generated projects.
 
+### Docker
+
+Start a local version via [docker-compose](https://docs.docker.com/compose/):
+
+    git clone git@github.com:webfactory/baton.git
+    cd baton
+    docker-compose up
+
 ## Tests
 
 Baton has Unit-Tests! Execute `bin/phpunit` to run them.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   baton:
     build: "docker/container/baton"
-    command: "dockerize -wait tcp://database:3306 php -v"
+    command: "dockerize -wait tcp://database:3306 bash -c 'composer install && php -v'"
     volumes:
       - .:/usr/app/baton
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2'
+
+services:
+  database:
+    image: mysql:5.7
+    volumes:
+      - database-content:/var/lib/mysql
+    restart: on-failure
+    environment:
+      MYSQL_DATABASE: "baton"
+      MYSQL_USER: "baton"
+      MYSQL_PASSWORD: "baton"
+      MYSQL_ROOT_PASSWORD: "baton"
+
+  baton:
+    build: "docker/container/baton"
+    command: "dockerize -wait tcp://database:3306 php -v"
+    volumes:
+      - .:/usr/app/baton
+    restart: on-failure
+    depends_on:
+      - database
+    ports:
+      - "8080:8080"
+
+volumes:
+  database-content:

--- a/docker/container/baton/Dockerfile
+++ b/docker/container/baton/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.2
+
+RUN apt-get update && apt-get install -y wget
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+WORKDIR /usr/app/baton

--- a/docker/container/baton/Dockerfile
+++ b/docker/container/baton/Dockerfile
@@ -1,10 +1,21 @@
+# Get the Composer executable from the official Composer image.
+FROM composer:1.6 as composer
+
+# Run Baton in a small PHP container.
 FROM php:7.2
 
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update
 
+# Install dockerize to be able to wait for the MySQL server.
+RUN apt-get install -y wget
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# Install Composer and required extensions.
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+RUN apt-get install -y git zlib1g-dev \
+    && docker-php-ext-install zip
 
 WORKDIR /usr/app/baton


### PR DESCRIPTION
Defines a PHP container for Baton.
Provides a `docker-compose.yml` file that spins up a MySQL database and the app container that waits for the database:

    docker-compose up

The current version *tries* to install Composer dependencies. But it seems as if several private packages are referenced.
When the dependencies have been installed successfully via `compose install`, the PHP version in the container is printed via `php -v`. This should be replaced by the command that starts the Baton server in the foreground.

Possible improvements:

- When mounted on Linux, dependency files are installed as `root` user. 
- The app (runtime) container contains Composer and its required tools. The image could be smaller as Composer is only needed at build time.
- ...