### PR TITLE
Support validating GitHub webhook secret HMACs

### DIFF
--- a/src/AppBundle/Controller/WebhookController.php
+++ b/src/AppBundle/Controller/WebhookController.php
@@ -33,11 +33,10 @@ class WebhookController
             $requestBody = $request->getContent();
             $hmac = hash_hmac('sha256', $requestBody, $this->webhookSecret);
 
-            if (!hash_equals($hmac, $request->headers->get('X-Hub-Signature-256'))) {
+            if (!hash_equals('sha256='.$hmac, $request->headers->get('X-Hub-Signature-256'))) {
                 throw new BadRequestHttpException('Invalid X-Hub-Signature-256 header');
             }
         }
-
         $repositoryWasImported = false;
 
         if ($payload = $request->get('payload')) {

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -20,6 +20,11 @@ services:
             $demoMode: "%demo_mode%"
         tags: [ 'controller.service_arguments' ]
 
+    AppBundle\Controller\WebhookController:
+        arguments:
+            $webhookSecret: "%app.github.webhook_secret%"
+        tags: [ 'controller.service_arguments' ]
+
     AppBundle\Entity\Repository\ProjectRepository:
         class: AppBundle\Entity\Repository\ProjectRepository
         factory: ["@doctrine.orm.entity_manager", getRepository]

--- a/src/config.default.yml
+++ b/src/config.default.yml
@@ -22,8 +22,9 @@ parameters:
   secret: "%env(SECRET)%"
   env(SECRET): "change_me"
   app.github.token: '%env(GITHUB_OAUTH_TOKEN)%'
-  env(GITHUB_OAUTH_TOKEN): # default is null, set this environment variable on your server to communicate with private repositories on GitHub
-
+  app.github.webhook_secret: '%env(GITHUB_WEBHOOK_SECRET)%'
+  env(GITHUB_OAUTH_TOKEN): ~ # default is null, set this environment variable on your server to communicate with private repositories on GitHub
+  env(GITHUB_WEBHOOK_SECRET): ~ # default is null, set this environment variable on your server to validate webhook payloads
 
 framework:
   secret:           "%secret%"


### PR DESCRIPTION
This allows to validate webhook payloads delivered by GitHub to be validated with a secret. The secret is used to derive a HMAC that is included as a header.

Configure the secret by setting the `GITHUB_WEBHOOK_SECRET` env variable.

Docs: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
