### PR TITLE
Fix `INSERT`s of duplicate `PackageVersion` entries (Case 208131)

### DIFF
--- a/src/AppBundle/Entity/Package.php
+++ b/src/AppBundle/Entity/Package.php
@@ -120,7 +120,10 @@ class Package
         );
 
         if ($packageVersion->isEmpty()) {
-            return new PackageVersion($prettyVersionString, $this);
+            $newVersion = new PackageVersion($prettyVersionString, $this);
+            $this->versions->add($newVersion);
+
+            return $newVersion;
         }
 
         return $packageVersion->first();

--- a/src/AppBundle/Entity/Project.php
+++ b/src/AppBundle/Entity/Project.php
@@ -155,7 +155,7 @@ class Project
 
             if (!$importedPackageVersionIsAlreadyInUse) {
                 $this->packageVersions->add($importedPackageVersion);
-                $packageVersion->addUsingProject($this);
+                $importedPackageVersion->addUsingProject($this);
             }
         }
     }

--- a/src/AppBundle/Tests/Entity/PackageTest.php
+++ b/src/AppBundle/Tests/Entity/PackageTest.php
@@ -35,4 +35,26 @@ class PackageTest extends TestCase
     {
         $this->assertSame(self::description, $this->package->getDescription());
     }
+
+    /**
+     * @test
+     */
+    public function getVersionReturnsSameInstanceOnRepeatedCallsWithSamePrettyVersionString()
+    {
+        $first = $this->package->getVersion('1.0.0');
+        $second = $this->package->getVersion('1.0.0');
+
+        $this->assertSame($first, $second);
+    }
+
+    /**
+     * @test
+     */
+    public function getVersionCreatesOnlyOnePackageVersionForSamePrettyVersionString()
+    {
+        $this->package->getVersion('1.0.0');
+        $this->package->getVersion('1.0.0');
+
+        $this->assertCount(1, $this->package->getVersions());
+    }
 }

--- a/src/AppBundle/Tests/Entity/ProjectTest.php
+++ b/src/AppBundle/Tests/Entity/ProjectTest.php
@@ -5,6 +5,7 @@ namespace AppBundle\Tests\Entity;
 use AppBundle\Entity\Package;
 use AppBundle\Entity\PackageVersion;
 use AppBundle\Entity\Project;
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 
 class ProjectTest extends TestCase
@@ -34,5 +35,18 @@ class ProjectTest extends TestCase
             self::name,
             $this->project->getPackageVersions()[0]->getProjects()[0]->getName()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function setUsedPackageVersionsSetsAssociationOnProjectAndPackageVersion(): void
+    {
+        $packageVersion = new PackageVersion('1.0.0', new Package('foo/bar'));
+
+        $this->project->setUsedPackageVersions(new ArrayCollection([$packageVersion]));
+
+        $this->assertContains($packageVersion, $this->project->getPackageVersions());
+        $this->assertContains($this->project, $packageVersion->getProjects());
     }
 }

--- a/src/AppBundle/Tests/Factory/VcsDriverFactoryTest.php
+++ b/src/AppBundle/Tests/Factory/VcsDriverFactoryTest.php
@@ -15,7 +15,7 @@ class VcsDriverFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->vcsDriverFactory = new VcsDriverFactory(null, 'bar');
+        $this->vcsDriverFactory = new VcsDriverFactory(null);
     }
 
     /**


### PR DESCRIPTION
Create only one new PackageVersion for each `$prettyVersionString`: If a new `PackageVersion` with the same `$prettyVersionString` is requested again in the same request, the already created one gets reused. This should fix a source of errors like the following:

> Uncaught PHP Exception Doctrine\DBAL\Exception\UniqueConstraintViolationException
>
> An exception occurred while executing 'INSERT INTO PackageVersion (prettyVersion, package_id) VALUES (?, ?)' with params ["3.2.2", 811]: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry ...

Bonus:
- Fix existing failing unit test
- Fix PackageVersion to set the using project to: `$packageVersion->addUsingProject($this)` seems wrong to me, as `$packageVersion` was always the last iterated element of `$this->packageVersions`. It seems to make more sense to set the used project to the same `$importedPackageVersion` object that was just added to `$this->packageVersions` in the line above.