### PR TITLE
Work around race condition during parallel import of projects (Case 208131)

### DIFF
--- a/src/AppBundle/ProjectImport/ImportProjectTask.php
+++ b/src/AppBundle/ProjectImport/ImportProjectTask.php
@@ -6,6 +6,7 @@ use AppBundle\Exception\InsufficientVcsAccessException;
 use AppBundle\Exception\ProjectHasNoComposerPackageUsageInfoException;
 use AppBundle\Factory\VcsDriverFactory;
 use Composer\Repository\Vcs\GitHubDriver;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -75,7 +76,13 @@ class ImportProjectTask
             $project->archived = $repoData['archived'] ?? false;
         }
 
-        $this->entityManager->flush();
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException $exception) {
+            $this->logger->warning('UniqueConstraintViolation during import of '.$vcsUrl.', likely a concurrent request.', ['exception' => $exception]);
+
+            return false;
+        }
 
         $this->logger->notice('Imported Project '.$project->getName());
 


### PR DESCRIPTION
When we squash-merge a GitHub PR, our GitHub organization webhook (which listens for pushes) is triggered twice: once for the deletion of the old branch and once for the merge commit. This usually happens within a second or less, and as the import of projects usually takes >= 5 seconds, we get a race condition here. For both requests, a new package version is not yet in the database, so both of them try to insert it.

I'm not convinced that this is the best way to deal with the race condition (prevention parallel runs in the first place might be better), but it's an easy workaround for now.
